### PR TITLE
Changing addon java version from1.8 to 11

### DIFF
--- a/add-on/pom.xml
+++ b/add-on/pom.xml
@@ -11,8 +11,8 @@
 	<name>Crud UI Add-on</name>
 
 	<properties>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/add-on/src/main/java/org/vaadin/crudui/form/FieldProvider.java
+++ b/add-on/src/main/java/org/vaadin/crudui/form/FieldProvider.java
@@ -9,8 +9,8 @@ import com.vaadin.flow.component.HasValueAndElement;
  * @author Alejandro Duarte.
  */
 @FunctionalInterface
-public interface FieldProvider<C extends Component, T> extends Serializable {
+public interface FieldProvider<C extends HasValueAndElement, T> extends Serializable {
 
-    HasValueAndElement buildField(T t);
+    C buildField(T t);
 
 }

--- a/add-on/src/main/java/org/vaadin/crudui/form/impl/field/provider/AbstractListingProvider.java
+++ b/add-on/src/main/java/org/vaadin/crudui/form/impl/field/provider/AbstractListingProvider.java
@@ -38,7 +38,7 @@ public abstract class AbstractListingProvider<C extends Component & HasListDataV
     }
 
     @Override
-    public HasValueAndElement<ComponentValueChangeEvent<C, T>, T> buildField(T t) {
+    public C buildField(T t) {
         C field = buildAbstractListing();
         field.setItems(items);
         return field;

--- a/crud-ui-demo/pom.xml
+++ b/crud-ui-demo/pom.xml
@@ -15,7 +15,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>11</java.version>
         <vaadin.version>23.1.3</vaadin.version>
     </properties>
 


### PR DESCRIPTION
Since we are using Vaadin 23, the minimum java supported is 11. Therefore I have updated both the addon and demo to use java 11.
The demo was using java 17, but I think in order to standardize the build process it should also use java 11.